### PR TITLE
Fix: removing 0 from offer detail

### DIFF
--- a/components/offerDetail/index.tsx
+++ b/components/offerDetail/index.tsx
@@ -196,7 +196,7 @@ export default function OfferDetail({
             {fraktionsBalance > 0 &&
             !isCanceledOffer() && 
               fraktionsApproved &&
-              fraktionsLocked &&
+              !!fraktionsLocked &&
               !offerItem?.winner && (
                 <Box
                   sx={{


### PR DESCRIPTION
Hi @cryptnotiq , just removed the 0 that is to the right of the accept button. 
I'm still not able to publish it in Gitcoin, maybe you have to approve it again.