### PR TITLE
Add Pending Buyer Claiming NFT message

### DIFF
--- a/components/offerDetail/index.tsx
+++ b/components/offerDetail/index.tsx
@@ -151,6 +151,9 @@ export default function OfferDetail({
             {!isCanceledOffer() && fraktionsBalance <= 0 && !isOfferer && (
               <Text>Buy Fraktions to vote!</Text>
             )}
+            {!isCanceledOffer() && fraktionsBalance > 0 && !isOfferer && !!offerItem?.winner && (
+              <Text>Pending Buyer Claiming NFT</Text>
+            )}
             {isCanceledOffer() && (<Text>Canceled</Text>)}
             {!isCanceledOffer() && 
             fraktionsBalance > 0 && !fraktionsApproved && (


### PR DESCRIPTION
Hi @cryptnotiq, just added the message that says "Pending Buyer Claiming NFT", regarding the "accept button issue" I'm not able to reproduce it, maybe it's a global state inconsistence or something random.