### PR TITLE
fix: min offer display value for nft buyout

### DIFF
--- a/components/buyOutCard/index.tsx
+++ b/components/buyOutCard/index.tsx
@@ -82,7 +82,7 @@ const BuyOutCard = ({
     }
   }
 
-  const minPriceParsed = (price) => roundUp(price, 3);
+  const minPriceParsed = (price) => roundUp(parseFloat(price), 3);
 
   function onSetValue(d) {
     if (BigNumber.from(d).gte(minPrice)) {
@@ -194,7 +194,7 @@ const BuyOutCard = ({
                   color: "#000000",
                 }}
               >
-                {utils.formatEther(minPrice)}
+                {minPriceParsed(utils.formatEther(minPrice))}
               </div>
             </HStack>
           </VStack>

--- a/components/buyOutCard/index.tsx
+++ b/components/buyOutCard/index.tsx
@@ -85,7 +85,7 @@ const BuyOutCard = ({
   const minPriceParsed = (price) => roundUp(parseFloat(price), 3);
 
   function onSetValue(d) {
-    if (BigNumber.from(d).gte(minPrice)) {
+    if (utils.parseEther(d).gte(minPrice)) {
       setValueToOffer(d);
       setIsReady(true);
     } else {

--- a/components/buyOutCard/index.tsx
+++ b/components/buyOutCard/index.tsx
@@ -1,7 +1,7 @@
 import { Divider } from "@chakra-ui/react";
 import { VStack, HStack, Box, Stack } from "@chakra-ui/layout";
 import React, { useState, useEffect } from "react";
-import { utils } from "ethers";
+import { utils, BigNumber } from "ethers";
 import FrakButton from "../button";
 import FrakButton2 from "../button2";
 import OfferDetail from "../offerDetail";
@@ -69,28 +69,23 @@ const BuyOutCard = ({
     setOffering(true);
     try {
       addEthAmount(valueToOffer);
-      let tx = await makeOffer(
+      await makeOffer(
         utils.parseEther(valueToOffer),
         tokenAddress,
         provider,
         marketAddress
-      ).then((receipt) => {
-        setOffering(false);
-        setValueToOffer("0");
-      }).catch(error => {
-        buyOutRejected(error, onOffer);
-      });
+      );
+      setOffering(false);
+      setValueToOffer("0");
     } catch (err) {
-      console.error("Error: ", err);
+      buyOutRejected(err, onOffer);
     }
   }
 
-  const minPriceParsed = minPrice => {
-    return (roundUp(minPrice, 3));
-  };
+  const minPriceParsed = (price) => roundUp(price, 3);
 
   function onSetValue(d) {
-    if (parseFloat(d) && parseFloat(d) >= minPrice) {
+    if (BigNumber.from(d).gte(minPrice)) {
       setValueToOffer(d);
       setIsReady(true);
     } else {
@@ -199,7 +194,7 @@ const BuyOutCard = ({
                   color: "#000000",
                 }}
               >
-                {minPriceParsed(minPrice)}
+                {utils.formatEther(minPrice)}
               </div>
             </HStack>
           </VStack>

--- a/components/revenuesDetail/index.tsx
+++ b/components/revenuesDetail/index.tsx
@@ -128,7 +128,7 @@ const RevenuesDetail = forwardRef<HTMLDivElement, revenueItemProps>(
           gains
         </Text>
         {/* value = total value, shares = shares the user has */}
-        <div>{(value / 10 ** 18) * (Number(utils.formatEther(shares)) / Number(utils.formatEther(totalShares)))} ETH</div>
+        <div>{(Number(value) / 10 ** 18) * (Number(utils.formatEther(shares)) / Number(utils.formatEther(totalShares)))} ETH</div>
         {isClaimable() && (
           <div>
             {buyout && !isApproved ? (

--- a/pages/nft/[id]/details.tsx
+++ b/pages/nft/[id]/details.tsx
@@ -36,7 +36,7 @@ export default function DetailsView() {
   const router = useRouter();
   const { account, provider, marketAddress, factoryAddress } = useWeb3Context();
   const [offers, setOffers] = useState();
-  const [minOffer, setMinOffer] = useState(0);
+  const [minOffer, setMinOffer] = useState<BigNumber>(BigNumber.from(0));
   const [nftObject, setNftObject] = useState({});
   const [tokenAddress, setTokenAddress] = useState<string>("");
   const [fraktionsListed, setFraktionsListed] = useState([]);
@@ -160,18 +160,17 @@ export default function DetailsView() {
 
   async function getOffers() {
     if (tokenAddress && marketAddress) {
-      let minPriceParsed;
       try {
         let minPrice:BigNumber = await getMinimumOffer(
           tokenAddress,
           provider,
           marketAddress
         );
-        minPriceParsed = utils.formatEther(minPrice.div(utils.parseEther("1.0")));
-      } catch {
-        minPriceParsed = 0;
+
+        setMinOffer(minPrice);
+      } catch (err) {
+        console.error('unable to retreive minimum offer');
       }
-      setMinOffer(minPriceParsed);
     }
   }
 


### PR DESCRIPTION
Related to issue #178 

Updated the minimum price related code to maintain BigNumber typing everywhere and only convert to a string when being displayed. Note that the call to `roundUp` on the minimum price value has been removed and is using default `formatEther` functionality until the `roundUp` function properly handles BigNumbers.