### PR TITLE
Fix: Design Fix #233

### DIFF
--- a/components/button2/index.tsx
+++ b/components/button2/index.tsx
@@ -58,8 +58,9 @@ const FrakButton2 = forwardRef<
               fontSize: '14px',
               maxWidth: '50px',
               padding: '4px',
+              wordWrap: 'initial',
               position: 'relative',
-              marginRight: `110px`,
+              marginRight: `130px`,
               boxSizing: `content-box`,
               transform: `translateX(2px) translateY(-2px)`,
             }}

--- a/components/buyOutCard/index.tsx
+++ b/components/buyOutCard/index.tsx
@@ -226,7 +226,7 @@ const BuyOutCard = ({
                 setFunction={onSetValue}
                 currency={'ETH'}
               >
-                {offering ? "Making Offer" : "Make Buy-out Offer"}
+                {offering ? "Making Offer" : "Buy Out"}
               </FrakButton2>
             </Stack>
           )}


### PR DESCRIPTION
Disable `word-wrap` in `Text` component. Change Button text to "Buy-Out" to make it fit within the Button
- Addresses #233 
Is there a way we can make the second button text shorter? The longer button text overflows out the button